### PR TITLE
help: add plugin commands listing

### DIFF
--- a/src/ciel/main.go
+++ b/src/ciel/main.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-	"ciel-driver"
 	"fmt"
 	"log"
 	"math/rand"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
+
+	"ciel-driver"
 )
 
 const (
@@ -241,28 +240,17 @@ func cielHelp() int {
 	fmt.Println("")
 	fmt.Println("\tshell  [<cmdline>]")
 	fmt.Println("\trawcmd <cmd> <arg1> <arg2> ...")
+	fmt.Println("")
+
+	fmt.Println("Plugins:")
+	Plugins := getPlugins()
+	for _, Plugin := range Plugins {
+		fmt.Printf("\t%s\n", Plugin.Name)
+	}
 	return 0
 }
 
 func cielVersion() int {
 	fmt.Println(Version)
-	return 0
-}
-
-func cielPlugin() int {
-	proc := LibExecDir + "/ciel-plugin/ciel-" + SubCommand
-	cmd := exec.Command(proc, SubArgs...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitStatus := exitError.Sys().(syscall.WaitStatus)
-			return exitStatus.ExitStatus()
-		}
-		log.Printf("failed to run plugin %s: %v\n", SubCommand, err)
-		return 1
-	}
 	return 0
 }

--- a/src/ciel/plugin.go
+++ b/src/ciel/plugin.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 )
 
 const (
-	PluginDir = LibExecDir + "/ciel-plugin/"
+	PluginDir    = LibExecDir + "/ciel-plugin/"
+	PluginPrefix = "ciel-"
 )
 
 // Plugin defines a ciel plugin
@@ -20,7 +22,7 @@ type Plugin struct {
 }
 
 func cielPlugin() int {
-	proc := PluginDir + "ciel-" + SubCommand
+	proc := PluginDir + PluginPrefix + SubCommand
 	cmd := exec.Command(proc, SubArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -47,8 +49,8 @@ func getPlugins() []Plugin {
 			return nil
 		}
 		fname := f.Name()
-		if len(fname) > 5 && fname[:5] == `ciel-` {
-			Plugins = append(Plugins, Plugin{Name: fname[5:]})
+		if len(fname) > len(PluginPrefix) && strings.HasPrefix(fname, PluginPrefix) {
+			Plugins = append(Plugins, Plugin{Name: fname[len(PluginPrefix):]})
 		}
 		return nil
 	})

--- a/src/ciel/plugin.go
+++ b/src/ciel/plugin.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	PluginDir = LibExecDir + "/ciel-plugin/"
+)
+
+// Plugin defines a ciel plugin
+type Plugin struct {
+	Name string
+	// TODO: get script usage from header comments
+	Usage string
+}
+
+func cielPlugin() int {
+	proc := PluginDir + "ciel-" + SubCommand
+	cmd := exec.Command(proc, SubArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitStatus := exitError.Sys().(syscall.WaitStatus)
+			return exitStatus.ExitStatus()
+		}
+		log.Printf("failed to run plugin %s: %v\n", SubCommand, err)
+		return 1
+	}
+	return 0
+}
+
+func getPlugins() []Plugin {
+	var Plugins []Plugin
+	err := filepath.Walk(PluginDir, func(path string, f os.FileInfo, err error) error {
+		if f == nil {
+			return err
+		}
+		if f.IsDir() {
+			return nil
+		}
+		fname := f.Name()
+		if len(fname) > 5 && fname[:5] == `ciel-` {
+			Plugins = append(Plugins, Plugin{Name: fname[5:]})
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("failed to walk in directory: %v\n", err)
+	}
+	return Plugins
+}

--- a/src/ciel/plugin.go
+++ b/src/ciel/plugin.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"syscall"
 )
@@ -41,21 +41,19 @@ func cielPlugin() int {
 
 func getPlugins() []Plugin {
 	var Plugins []Plugin
-	err := filepath.Walk(PluginDir, func(path string, f os.FileInfo, err error) error {
-		if f == nil {
-			return err
-		}
-		if f.IsDir() {
-			return nil
-		}
-		fname := f.Name()
-		if len(fname) > len(PluginPrefix) && strings.HasPrefix(fname, PluginPrefix) {
-			Plugins = append(Plugins, Plugin{Name: fname[len(PluginPrefix):]})
-		}
-		return nil
-	})
+	files, err := ioutil.ReadDir(PluginDir)
 	if err != nil {
-		log.Fatalf("failed to walk in directory: %v\n", err)
+		log.Fatalf("failed to get files under plugin directory: %v\n", err)
+	}
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		} else {
+			fname := f.Name()
+			if len(fname) > len(PluginPrefix) && strings.HasPrefix(fname, PluginPrefix) {
+				Plugins = append(Plugins, Plugin{Name: fname[len(PluginPrefix):]})
+			}
+		}
 	}
 	return Plugins
 }


### PR DESCRIPTION
- Shows a list of plugin commands available in Help.
- TODO: define usage in plugin scripts and show them in help