### PR TITLE
Build: add travis build manifest and cross-architecture build check

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,19 @@
+language: go
+sudo: required
+go:
+  - 1.7.6
+  - 1.8.3
+  - tip
+os:
+  - linux
+  - osx
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
+install:
+  - make install
+script:
+  - make
+  - make cross-all
+  - make check

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
 PREFIX:=/usr
 PLGDIR:=$(PREFIX)/libexec/ciel-plugin
 BINDIR:=$(PREFIX)/bin
+ARCHS:=amd64 386 arm64 arm mips64le mipsle ppc64 # no powerpc 32 yet
 
 all:
 	git submodule update --init
 	sed -e "s|@VERSION@|r`git rev-list --count HEAD`.`git rev-parse --short HEAD`|g" src/ciel/version.go.in > src/ciel/version.go
 	GOPATH="$$PWD" go build ciel
+
+cross-all:
+	git submodule update --init
+	sed -e "s|@VERSION@|r`git rev-list --count HEAD`.`git rev-parse --short HEAD`|g" src/ciel/version.go.in > src/ciel/version.go
+	for arch in $(ARCHS); \
+	do \
+		echo "Cross compiling ciel for Linux/$$arch ..."; \
+		GOPATH="$$PWD" GOOS="linux" GOARCH="$$arch" go build -o /tmp/ciel-$$arch ciel; \
+	done
+
+check:
+	git submodule update --init
+	GOPATH="$$PWD" go test ciel
+	GOPATH="$$PWD" go test ciel-driver
 
 install:
 	install -Dm755 ciel $(BINDIR)


### PR DESCRIPTION
- Build and run tests on every commit
- Make cross-all to build ciel for multiple architectures