### PR TITLE
guest_os.go: merge full-upgrade and autoremove

### DIFF
--- a/guest_os.go
+++ b/guest_os.go
@@ -210,15 +210,8 @@ func update() {
 	}
 	d.OK()
 
-	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --yes`)
-	d.ITEM("update packages")
-	if runErr != nil || exitStatus != 0 {
-		panic(ExitError{})
-	}
-	d.OK()
-
-	exitStatus, runErr = run(`apt autoremove --purge --yes`)
-	d.ITEM("auto-remove packages")
+	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --autoremove --purge --yes`)
+	d.ITEM("update and auto-remove packages")
 	if runErr != nil || exitStatus != 0 {
 		panic(ExitError{})
 	}


### PR DESCRIPTION
Since APT can simultaneously full-upgrade a system and purge unnecessary packages we let APT to do all these at once.