### PR TITLE
[WIP] Replace all `apt` with `apt-get`.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@ func docHelp() {
 	ciel load-os [TAR_FILE]    // unpack OS tarball or fetch the latest BuildKit from internet directly
 	ciel load-tree [GIT_URL]   // clone package tree from your link or AOSC OS ABBS at GitHub
 
-	ciel update-os      // similar to 'apt update && apt full-upgrade'
+	ciel update-os      // similar to 'apt-get update && apt-get dist-upgrade'
 	ciel update-tree    // similar to 'git pull'
 
 	ciel [list]

--- a/guest_os.go
+++ b/guest_os.go
@@ -203,14 +203,14 @@ func update() {
 		}
 	}()
 
-	exitStatus, runErr = run(`apt update --yes`)
+	exitStatus, runErr = run(`apt-get update --yes`)
 	d.ITEM("update database")
 	if runErr != nil || exitStatus != 0 {
 		panic(ExitError{})
 	}
 	d.OK()
 
-	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --autoremove --purge --yes`)
+	exitStatus, runErr = run(`apt-get -o Dpkg::Options::="--force-confnew" dist-upgrade --autoremove --purge --yes`)
 	d.ITEM("update and auto-remove packages")
 	if runErr != nil || exitStatus != 0 {
 		panic(ExitError{})

--- a/plugin/ciel-generate
+++ b/plugin/ciel-generate
@@ -147,13 +147,13 @@ _recipe_post() {
 _recipe_pre_install() {
 	ciel update-os
 	ciel add $CIEL_INST
-	ciel shell "apt -o Dpkg::Options::=\"--force-confnew\" install --yes ${PREREQ_RECIPE}"
+	ciel shell "apt-get -o Dpkg::Options::=\"--force-confnew\" install --yes ${PREREQ_RECIPE}"
 }
 
 # Recipe-specific functions.
 _recipe_install() {
-	ciel shell "apt -o Dpkg::Options::=\"--force-confnew\" install --yes ${!CALCULATED_RECIPE}"
-	ciel shell "apt autoremove --purge --yes"
+	ciel shell "apt-get -o Dpkg::Options::=\"--force-confnew\" install --yes ${!CALCULATED_RECIPE}"
+	ciel shell "apt-get autoremove --purge --yes"
 }
 _recipe_base_config() {
 	# FIXME: preset.
@@ -171,7 +171,7 @@ _recipe_base_config() {
 _recipe_sunxi-base_pre_install() {
 	ciel shell "echo deb https://repo.aosc.io/debs stable bsp-sunxi > /etc/apt/sources.list.d/sunxi.list"
 	ciel commit
-	ciel shell "apt update"
+	ciel shell "apt-get update"
 }
 _recipe_sunxi-base_config(){
 	# FIXME: preset.
@@ -186,7 +186,7 @@ _recipe_sunxi-base_config(){
 _recipe_sunxi64-base_pre_install() {
 	ciel shell "echo deb https://repo.aosc.io/debs stable bsp-sunxi > /etc/apt/sources.list.d/sunxi.list"
 	ciel commit
-	ciel shell "apt update"
+	ciel shell "apt-get update"
 }
 _recipe_sunxi64-base_config(){
 	# FIXME: preset.
@@ -204,7 +204,7 @@ _recipe_sunxi64-base_config(){
 _recipe_sunxi64-mate_pre_install() {
 	ciel shell "echo deb https://repo.aosc.io/debs stable bsp-sunxi > /etc/apt/sources.list.d/sunxi.list"
 	ciel commit
-	ciel shell "apt update"
+	ciel shell "apt-get update"
 }
 _recipe_sunxi64-mate_config(){
 	# FIXME: preset.


### PR DESCRIPTION
## See also

[SCRIPT USAGE AND DIFFERENCES FROM OTHER APT TOOLS - Ubuntu Manpage: apt - command-line interface](https://manpages.ubuntu.com/manpages/disco/en/man8/apt.8.html#script%20usage%20and%20differences%20from%20other%20apt%20tools)