### PR TITLE
guest_os.go: pass parameters to apt in update function

### DIFF
--- a/guest_os.go
+++ b/guest_os.go
@@ -210,7 +210,7 @@ func update() {
 	}
 	d.OK()
 
-	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --autoremove --purge --yes` + strings.Join(flag.Args(), " "))
+	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --autoremove --purge --yes ` + strings.Join(flag.Args(), " "))
 	d.ITEM("update and auto-remove packages")
 	if runErr != nil || exitStatus != 0 {
 		panic(ExitError{})

--- a/guest_os.go
+++ b/guest_os.go
@@ -210,7 +210,7 @@ func update() {
 	}
 	d.OK()
 
-	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --autoremove --purge --yes`)
+	exitStatus, runErr = run(`apt -o Dpkg::Options::="--force-confnew" full-upgrade --autoremove --purge --yes` + strings.Join(flag.Args(), " "))
 	d.ITEM("update and auto-remove packages")
 	if runErr != nil || exitStatus != 0 {
 		panic(ExitError{})


### PR DESCRIPTION
Example: `ciel update-os -- --dry-run systemd=1:241 ppp=2.4.7-3`