### PR TITLE
mod: switch to use go mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: required
 go:
-  - 1.7.x
-  - 1.9.x
+  - 1.11.x
+  - 1.13.x
   - tip
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ GOBIN=$(GOPATH)/bin
 CIELPATH=$(GOSRC)/ciel
 
 DISTDIR=$(SRCDIR)/instdir
-GLIDE=$(GOBIN)/glide
 
 all: build
 
@@ -27,24 +26,8 @@ $(CIELPATH):
 	mkdir -p $(GOBIN)
 	ln -f -s -T $(SRCDIR) $(CIELPATH)
 
-ifeq ($(ARCH), ppc64)
-deps: $(CIELPATH)
-	go get -u github.com/godbus/dbus
-else ifeq ($(ARCH), ppc)
-deps: $(CIELPATH)
-	go get -u github.com/godbus/dbus
-else ifeq ($(ARCH), aarch64)
-deps: $(CIELPATH)
-	go get -u github.com/godbus/dbus
-else
-$(GLIDE):
-	curl -\# https://glide.sh/get | PATH=$(GOBIN):$(PATH) sh
-
-deps: $(CIELPATH) $(GLIDE) $(SRCDIR)/glide.yaml
-	cd $(CIELPATH)
-	$(GLIDE) install
-	cd $(SRCDIR)
-endif
+deps: $(CIELPATH) $(SRCDIR)/go.mod $(SRCDIR)/go.sum
+	go mod vendor
 
 config:
 	cp $(SRCDIR)/_config.go $(SRCDIR)/config.go

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,0 @@
-package: ciel
-import:
-- package: github.com/godbus/dbus
-  version: ^4.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module ciel
+
+go 1.13
+
+require github.com/godbus/dbus v4.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
+github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=


### PR DESCRIPTION
Switch to use `go mod`, the official package management tool since Go 1.11.

Ditched Glide and all related files are removed.